### PR TITLE
New JSONError case

### DIFF
--- a/Sources/JSON/JSON+Parse.swift
+++ b/Sources/JSON/JSON+Parse.swift
@@ -3,6 +3,7 @@ import Jay
 
 public enum JSONError: Error {
     case allowFragmentsNotSupported
+    case parse(path: String, error: Error)
 }
 
 extension JSON {


### PR DESCRIPTION
Used when parsing configs while initializing Droplet

See https://github.com/vapor/vapor/pull/727

