### PR TITLE
Added the "Permit" extension

### DIFF
--- a/Sources/JSON/JSON+Permit.swift
+++ b/Sources/JSON/JSON+Permit.swift
@@ -1,11 +1,11 @@
 import Node
 
 extension JSON {
-    public func permit(_ params: [String]) -> JSON {
+    public func permit(_ keys: [String]) -> JSON {
         guard var object = node.object as? [String:Node] else { return self }
         
         object.forEach { key,_ in
-            if(!params.contains(key)) {
+            if(!keys.contains(key)) {
                 object[key] = nil
             }
         }

--- a/Sources/JSON/JSON+Permit.swift
+++ b/Sources/JSON/JSON+Permit.swift
@@ -1,15 +1,15 @@
 import Node
 
 extension JSON {
-    func permit(_ params: [String]) -> JSON {
+    public func permit(_ params: [String]) -> JSON {
         guard var object = node.object as? [String:Node] else { return self }
         
-        for (key, _) in object {
+        object.forEach { key,_ in
             if(!params.contains(key)) {
                 object[key] = nil
             }
         }
-        
+
         return JSON(Node.object(object))
     }
 }

--- a/Sources/JSON/JSON+Permit.swift
+++ b/Sources/JSON/JSON+Permit.swift
@@ -1,0 +1,15 @@
+import Node
+
+extension JSON {
+    func permit(_ params: [String]) -> JSON {
+        guard var object = node.object as? [String:Node] else { return self }
+        
+        for (key, _) in object {
+            if(!params.contains(key)) {
+                object[key] = nil
+            }
+        }
+        
+        return JSON(Node.object(object))
+    }
+}

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -108,8 +108,11 @@ class JSONTests: XCTestCase {
     }
     
     func testPermit() throws {
-        let json = try JSON(node: ["hello": "world",
-                                   "from":"🚀"])
+        let json = try JSON(node: [
+            "hello": "world",
+            "from": "🚀"
+        ])
+        
         let saneJson = json.permit(["hello"])
         XCTAssertEqual(saneJson["hello"]?.string, "world")
         XCTAssertEqual(saneJson["from"]?.string, nil)

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -13,6 +13,7 @@ class JSONTests: XCTestCase {
         ("testCrazyCommentInternal", testCrazyCommentInternal),
         ("testSerializePerformance", testSerializePerformance),
         ("testParsePerformance", testParsePerformance),
+        ("testPermit", testPermit),
     ]
 
     func testParse() throws {
@@ -104,6 +105,14 @@ class JSONTests: XCTestCase {
         let json = try JSON(node: ["he \r\n l \t l \n o w\"o\rrld "])
         let data = try json.serialize().string
         XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]")
+    }
+    
+    func testPermit() throws {
+        let json = try JSON(node: ["hello": "world",
+                                   "from":"🚀"])
+        let saneJson = json.permit(["hello"])
+        XCTAssertEqual(saneJson["hello"]?.string, "world")
+        XCTAssertEqual(saneJson["from"]?.string, nil)
     }
 
     var hugeParsed: JSON!


### PR DESCRIPTION
This allows to exclude some keys from the JSON object. It can be used in a Request extension like so: 

```
extension Request {   
    func post() throws -> Post {
        guard let json = json?.permit(["content"]) else { throw Abort.badRequest }
        return try Post(node: json)
    }
}
```

Before, any parameters could be given, which allowed any user to modify the id for example. It's not possible anymore now.