### PR TITLE
json context

### DIFF
--- a/Sources/JSON/File.swift
+++ b/Sources/JSON/File.swift
@@ -1,5 +1,5 @@
 import Node
 
-public struct JSONContext: Context {
+public final class JSONContext: Context {
     public init() {}
 }

--- a/Sources/JSON/File.swift
+++ b/Sources/JSON/File.swift
@@ -1,0 +1,5 @@
+import Node
+
+public struct JSONContext: Context {
+    public init() {}
+}

--- a/Sources/JSON/JSONRepresentable.swift
+++ b/Sources/JSON/JSONRepresentable.swift
@@ -10,10 +10,11 @@ public protocol JSONInitializable {
 
 public protocol JSONConvertible: JSONRepresentable, JSONInitializable {}
 
+private let _context = JSONContext()
+
 extension JSONRepresentable where Self: NodeRepresentable {
     public func makeJSON() throws -> JSON {
-        let context = JSONContext()
-        let node = try makeNode(context: context)
+        let node = try makeNode(context: _context)
         return try JSON(node: node)
     }
 }
@@ -21,8 +22,7 @@ extension JSONRepresentable where Self: NodeRepresentable {
 extension JSONInitializable where Self: NodeInitializable {
     public init(json: JSON) throws {
         let node = json.makeNode()
-        let context = JSONContext()
-        try self.init(node: node, in: context)
+        try self.init(node: node, in: _context)
     }
 }
 

--- a/Sources/JSON/JSONRepresentable.swift
+++ b/Sources/JSON/JSONRepresentable.swift
@@ -12,7 +12,8 @@ public protocol JSONConvertible: JSONRepresentable, JSONInitializable {}
 
 extension JSONRepresentable where Self: NodeRepresentable {
     public func makeJSON() throws -> JSON {
-        let node = try makeNode()
+        let context = JSONContext()
+        let node = try makeNode(context: context)
         return try JSON(node: node)
     }
 }
@@ -20,7 +21,8 @@ extension JSONRepresentable where Self: NodeRepresentable {
 extension JSONInitializable where Self: NodeInitializable {
     public init(json: JSON) throws {
         let node = json.makeNode()
-        try self.init(node: node)
+        let context = JSONContext()
+        try self.init(node: node, in: context)
     }
 }
 


### PR DESCRIPTION
Adds a `JSONContext` conforming to `Node.Context` that will be passed to all calls to `makeNode` and `init(node:` from the JSON module.

This will give more clarity to users as to what fields should be included in the Node for a particular call.