### PR TITLE
`makeJSON()` uniform behavior between SequenceType and its Element

### DIFF
--- a/Sources/JSON/Sequence+Convertible.swift
+++ b/Sources/JSON/Sequence+Convertible.swift
@@ -1,7 +1,8 @@
 import Node
 
-extension Sequence where Iterator.Element: NodeRepresentable {
+extension Sequence where Iterator.Element: JSONRepresentable {
     public func makeJSON() throws -> JSON {
-        return try self.makeNode().converted(to: JSON.self)
+        let mapped = try self.map({ try $0.makeJSON() })
+        return try JSON(node: mapped)
     }
 }

--- a/Sources/JSON/Sequence+Convertible.swift
+++ b/Sources/JSON/Sequence+Convertible.swift
@@ -5,3 +5,9 @@ extension Sequence where Iterator.Element: JSONRepresentable {
         return try JSON(node: self.map({ try $0.makeJSON() }))
     }
 }
+
+extension Sequence where Iterator.Element: NodeRepresentable {
+    public func makeJSON() throws -> JSON {
+        return try self.makeNode().converted(to: JSON.self)
+    }
+}

--- a/Sources/JSON/Sequence+Convertible.swift
+++ b/Sources/JSON/Sequence+Convertible.swift
@@ -2,12 +2,6 @@ import Node
 
 extension Sequence where Iterator.Element: JSONRepresentable {
     public func makeJSON() throws -> JSON {
-        return try JSON(node: self.map({ try $0.makeJSON() }))
-    }
-}
-
-extension Sequence where Iterator.Element: NodeRepresentable {
-    public func makeJSON() throws -> JSON {
-        return try self.makeNode().converted(to: JSON.self)
+        return try JSON(node: self.map { try $0.makeJSON() })
     }
 }

--- a/Sources/JSON/Sequence+Convertible.swift
+++ b/Sources/JSON/Sequence+Convertible.swift
@@ -2,7 +2,6 @@ import Node
 
 extension Sequence where Iterator.Element: JSONRepresentable {
     public func makeJSON() throws -> JSON {
-        let mapped = try self.map({ try $0.makeJSON() })
-        return try JSON(node: mapped)
+        return try JSON(node: self.map({ try $0.makeJSON() }))
     }
 }


### PR DESCRIPTION
Currently, calling `makeJSON()` on SequenceType returns the `makeNode()` implementation for each Element. This changes that to use the `makeJSON` defined in the Model. 

Also updated the protocol constraint to `JSONRepresentable` since the function is related to `JSON` and not `Node`.