### PR TITLE
fix top level fragment crash

### DIFF
--- a/Sources/JSON/JSON+Bytes.swift
+++ b/Sources/JSON/JSON+Bytes.swift
@@ -6,6 +6,6 @@ extension JSON: BytesConvertible {
     }
 
     public init(bytes: Bytes) throws {
-        try self.init(bytes: bytes, allowFragments: false)
+        try self.init(bytes: bytes, allowFragments: true)
     }
 }

--- a/Sources/JSON/JSON+Serialize.swift
+++ b/Sources/JSON/JSON+Serialize.swift
@@ -3,13 +3,31 @@ import Foundation
 
 extension JSON {
     public func serialize(prettyPrint: Bool = false) throws -> Bytes {
+        switch wrapped {
+        case .array, .object:
+            return try _nsSerialize(prettyPrint: prettyPrint)
+        case .bool(let b):
+            return b ? [.t, .r, .u, .e] : [.f, .a, .l, .s, .e]
+        case .bytes(let b):
+            return b
+        case .date, .string:
+            let bytes = string?.makeBytes() ?? []
+            return [.quote] + bytes + [.quote]
+        case .number:
+            return string?.makeBytes() ?? []
+        case .null:
+            return [.n, .u, .l, .l]
+        }
+    }
+    
+    private func _nsSerialize(prettyPrint: Bool) throws -> Bytes {
         let options: JSONSerialization.WritingOptions
         if prettyPrint {
             options = .prettyPrinted
         } else {
             options = .init(rawValue: 0)
         }
-
+        
         let json = wrapped.json
         let data = try JSONSerialization.data(
             withJSONObject: json,

--- a/Sources/JSON/JSON+Serialize.swift
+++ b/Sources/JSON/JSON+Serialize.swift
@@ -9,7 +9,8 @@ extension JSON {
         case .bool(let b):
             return b ? [.t, .r, .u, .e] : [.f, .a, .l, .s, .e]
         case .bytes(let b):
-            return b
+            let encoded = b.base64Encoded
+            return [.quote] + encoded + [.quote]
         case .date, .string:
             let bytes = string?.makeBytes() ?? []
             return [.quote] + bytes + [.quote]

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -103,4 +103,20 @@ class JSONTests: XCTestCase {
         let bytes = try json.serialize()
         XCTAssertEqual(bytes.makeString(), "\"foo\"")
     }
+    
+    func testSerializeDate() throws {
+        let date = Date(timeIntervalSince1970: 1489927411)
+        let json = JSON(.date(date))
+        let bytes = try json.serialize()
+        XCTAssertEqual(bytes.makeString(), "\"2017-03-19T12:43:31.000Z\"")
+    }
+    
+    func testSerializeBytes() throws {
+        let input = "foo".makeBytes()
+        let json = JSON(.bytes(input))
+        let bytes = try json.serialize()
+        XCTAssertEqual(bytes.makeString(), "\"Zm9v\"")
+        let parsed = try JSON(bytes: bytes)
+        XCTAssertEqual(parsed.bytes?.base64Decoded.makeString(), "foo")
+    }
 }

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -98,4 +98,9 @@ class JSONTests: XCTestCase {
         }
     }
 
+    func testSerializeFragment() throws {
+        let json = JSON("foo")
+        let bytes = try json.serialize()
+        XCTAssertEqual(bytes.makeString(), "\"foo\"")
+    }
 }

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -19,6 +19,9 @@ class JSONTests: XCTestCase {
         ("testSerialize", testSerialize),
         ("testSerializePerformance", testSerializePerformance),
         ("testParsePerformance", testParsePerformance),
+        ("testSerializeFragment", testSerializeFragment),
+        ("testSerializeDate", testSerializeDate),
+        ("testSerializeBytes", testSerializeBytes),
     ]
 
     func testParse() throws {


### PR DESCRIPTION
Fixes this exception with top level fragments:
```
file:///Users/tanner/dev/vapor/json/Tests/JSONTests/JSONTests.swift: test failure: -[JSONTests testSerializeFragment()] failed: failed: caught "NSInvalidArgumentException", "*** +[NSJSONSerialization dataWithJSONObject:options:error:]: Invalid top-level type in JSON write"
(
	0   CoreFoundation                      0x00007fff9537de7b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x00007fffa9f67cad objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff953fc99d +[NSException raise:format:] + 205
	3   Foundation                          0x00007fff96d19d5c +[NSJSONSerialization dataWithJSONObject:options:error:] + 249
	4   JSON                                0x00000001027b6cde _TFV4JSON4JSONP33_516DA0B90D413AFA425E0AA09FFDCE7C12_nsSerializefzT11prettyPrintSb_GSaVs5UInt8_ + 510
	5   JSON                                0x00000001027b6a97 _TFV4JSON4JSON9serializefzT11prettyPrintSb_GSaVs5UInt8_ + 39
	6   JSONTests                           0x0000000102565f5a _TFC9JSONTests9JSONTests21testSerializeFragmentfzT_T_ + 218
	7   JSONTests                           0x00000001025664a2 _TToFC9JSONTests9JSONTests21testSerializeFragmentfzT_T_ + 50
	8   CoreFoundation                      0x00007fff952f13ec __invoking___ + 140
	9   CoreFoundation                      0x00007fff952f1271 -[NSInvocation invoke] + 289
	10  XCTest                              0x00000001000bcd94 __24-[XCTestCase invokeTest]_block_invoke.234 + 50
	11  XCTest                              0x000000010010300a -[XCTMemoryChecker _assertInvalidObjectsDeallocatedAfterScope:] + 37
	12  XCTest                              0x00000001000bc958 __24-[XCTestCase invokeTest]_block_invoke_2 + 665
	13  XCTest                              0x00000001000fac2e -[XCTestContext performInScope:] + 190
	14  XCTest                              0x00000001000bc6ac -[XCTestCase invokeTest] + 254
	15  XCTest                              0x00000001000bd11b -[XCTestCase performTest:] + 565
	16  XCTest                              0x00000001000ba08e __27-[XCTestSuite performTest:]_block_invoke + 300
	17  XCTest                              0x00000001000b9c7e -[XCTestSuite _performProtectedSectionForTest:testSection:] + 29
	18  XCTest                              0x00000001000b9e64 -[XCTestSuite performTest:] + 214
	19  XCTest                              0x00000001000ba08e __27-[XCTestSuite performTest:]_block_invoke + 300
	20  XCTest                              0x00000001000b9c7e -[XCTestSuite _performProtectedSectionForTest:testSection:] + 29
	21  XCTest                              0x00000001000b9e64 -[XCTestSuite performTest:] + 214
	22  XCTest                              0x00000001000ba08e __27-[XCTestSuite performTest:]_block_invoke + 300
	23  XCTest                              0x00000001000b9c7e -[XCTestSuite _performProtectedSectionForTest:testSection:] + 29
	24  XCTest                              0x00000001000b9e64 -[XCTestSuite performTest:] + 214
	25  XCTest                              0x000000010010db70 __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke + 40
	26  XCTest                              0x00000001000d07bf -[XCTestObservationCenter _observeTestExecutionForBlock:] + 587
	27  XCTest                              0x000000010010da0e -[XCTTestRunSession runTestsAndReturnError:] + 281
	28  XCTest                              0x00000001000a5b13 -[XCTestDriver runTestsAndReturnError:] + 254
	29  XCTest                              0x00000001000fd2e1 _XCTestMain + 773
	30  xctest                              0x000000010000148d xctest + 5261
	31  libdyld.dylib                       0x00007fffaa84b255 start + 1
)
```