### PR TITLE
Add support for `.sortedKeys` option on JSONSerialization

### DIFF
--- a/Sources/JSON/JSON+Serialize.swift
+++ b/Sources/JSON/JSON+Serialize.swift
@@ -2,10 +2,10 @@ import Core
 import Foundation
 
 extension JSON {
-    public func serialize(prettyPrint: Bool = false) throws -> Bytes {
+    public func serialize(prettyPrint: Bool = false, sortedKeys: Bool = false) throws -> Bytes {
         switch wrapped {
         case .array, .object:
-            return try _nsSerialize(prettyPrint: prettyPrint)
+            return try _nsSerialize(prettyPrint: prettyPrint, sortedKeys: sortedKeys)
         case .bool(let b):
             return b ? [.t, .r, .u, .e] : [.f, .a, .l, .s, .e]
         case .bytes(let b):
@@ -21,12 +21,13 @@ extension JSON {
         }
     }
     
-    private func _nsSerialize(prettyPrint: Bool) throws -> Bytes {
-        let options: JSONSerialization.WritingOptions
+    private func _nsSerialize(prettyPrint: Bool, sortedKeys: Bool) throws -> Bytes {
+        var options = JSONSerialization.WritingOptions()
         if prettyPrint {
-            options = .prettyPrinted
-        } else {
-            options = .init(rawValue: 0)
+            options.insert(.prettyPrinted)
+        }
+        if sortedKeys {
+            options.insert(.sortedKeys)
         }
 
         let data = try JSONSerialization.data(


### PR DESCRIPTION
iOS 11 and macOS 10.13 introduce a new `sortedKeys` option for `JSONSerialization.WrittingOptions` which allows to serialize JSON objects with their keys sorted alphabetically.

See [Apple's documentation](https://developer.apple.com/documentation/foundation/jsonserialization.writingoptions/2888322-sortedkeys) for more information.