### PR TITLE
Fix CircleCI configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
+dependencies:
+  override:
+    - eval "$(curl -sL https://apt.vapor.sh)"
+    - sudo apt-get install vapor
+    - sudo chmod -R a+rx /usr/
+
 test:
   override:
-    - eval "$(curl -sL https://swift.vapor.sh/ci-3.1)"
+    - swift build -c release
+    - swift test


### PR DESCRIPTION
The swift.vapor.sh domain has been unavailable for a while, causing the CI builds of _every_ old project to silently report false positives. This vapor/json repo is among the affected projects.

Sidenote: this is still a CircleCI 1.0 configuration.